### PR TITLE
Make High Replication the default.

### DIFF
--- a/context.go
+++ b/context.go
@@ -212,6 +212,7 @@ func (c *Context) startChild() error {
 	c.child = exec.Command(
 		devAppserver,
 		"--clear_datastore",
+		"--high_replication",
 		// --blobstore_path=... <tempdir>
 		// --datastore_path=DS_FILE
 		"--skip_sdk_update_check",


### PR DESCRIPTION
App Engine has depreciated the master / slave datastore:

http://googleappengine.blogspot.com/2012/04/masterslave-datastore-thanks-for-all.html

What do you think about making "high replication" the default?
